### PR TITLE
fix to work with image urls containing special chars (ex. "(" or ")" )

### DIFF
--- a/lib/js/jquery.maximage.js
+++ b/lib/js/jquery.maximage.js
@@ -111,7 +111,7 @@
 							var $img = $.Slides[i];
 							
 							// Create a div with a background image so we can use CSS3's position cover (for modern browsers)
-							$self.append('<div class="mc-image ' + $img.theclass + '" title="' + $img.alt + '" style="background-image:url(' + $img.url + ');' + $img.style + '"></div>');
+							$self.append('<div class="mc-image ' + $img.theclass + '" title="' + $img.alt + '" style="background-image:url(\'' + $img.url + '\');' + $img.style + '"></div>');
 						}
 						
 						// Begin our preload process (increments itself after load)


### PR DESCRIPTION
Wrapped the background-image url with quotations so that special characters in the name of the file don't break functionality. 

I didn't minify, as I'm not sure what lib you're using for minification.
