### PR TITLE
Please preserve original image classes in "Old Browser" mode

### DIFF
--- a/lib/js/jquery.maximage.js
+++ b/lib/js/jquery.maximage.js
@@ -237,7 +237,7 @@
 							}
 							
 							// Create Div
-							$div = $("<div>" + c + "</div>").attr("class", "mc-image mc-image-n" + j)
+							$div = $("<div>" + c + "</div>").attr("class", "mc-image mc-image-n" + j + " " + $.Slides[j].theclass);
 							
 							// Add new container div to the DOM
 							$self.append( $div );


### PR DESCRIPTION
In "Old Browser" mode (aka IE8) the classes of the original objects don't get passed through when images are replaced with divs. This can break other scripts that expect to operate on those class names.
