### PR TITLE
Unexpected additional elements #12

### DIFF
--- a/lib/js/jquery.maximage.js
+++ b/lib/js/jquery.maximage.js
@@ -102,8 +102,11 @@
 			var Modern = {
 				setup: function(){
 					if($.Slides.length > 0){
+						var i,
+							len = $.Slides.length;
+							
 						// Setup images
-						for(var i in $.Slides) {
+						for(i=0; i < len; i++) {
 							// Set our image
 							var $img = $.Slides[i];
 							


### PR DESCRIPTION
...rects the elements to be append at $self; located at setup method of Modern object.
#12: Fixes this issue. There was a bug at line 106. Currently, it also loops on the inherited properties of $.Slides, and creates the superflous generated slides reported at issue #12

//EXACT CODE
for(var i in $.Slides) {
    // Set our image
    var $img = $.Slides[i];

//FIX
    var     i,
        len = $.Slides.length;

```
// Setup images
for(i=0; i < len; i++) {
    // Set our image
    var $img = $.Slides[i];
```
