### PR TITLE
ie8 scrolling fix if you remove the slider

### DIFF
--- a/lib/js/jquery.maximage.js
+++ b/lib/js/jquery.maximage.js
@@ -341,7 +341,10 @@
 						.bind($.Events.RESIZE,
 						function(){
 							clearTimeout(this.id);
-							this.id = setTimeout(Old.doneResizing, 200);
+
+							if($('.mc-image').length >= 1){
+								this.id = setTimeout(Old.doneResizing, 200);
+							}
 						});
 				},
 				doneResizing: function(){


### PR DESCRIPTION
allow the user to scroll down in the page if you remove the slider in
IE8 and below. Right now you are stuck at the top of the page.
