### PR TITLE
Make plugin compatible with jQuery 3.0

### DIFF
--- a/lib/js/jquery.maximage.js
+++ b/lib/js/jquery.maximage.js
@@ -127,7 +127,7 @@
 					
 					// Create new image object
 					var $img = $('<img/>');
-					$img.load(function() {
+					$img.on('load', function() {
 						// Once the first image has completed loading, start the slideshow, etc.
 						if(preload_count==0) {
 							// Only start cycle after first image has loaded


### PR DESCRIPTION
`.load` was completely deprecated, the canonical way is to use `.on('load', callback)`
